### PR TITLE
Only employees can assign caretakers

### DIFF
--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -12,6 +12,8 @@ export const Animal = ({ animal, syncAnimals,
     const [detailsOpen, setDetailsOpen] = useState(false)
     const [isEmployee, setAuth] = useState(false)  
     const [myOwners, setPeople] = useState([])
+    const [myCaretakers, setCaretakers] = useState([])
+    const [allCaretakers, assignCaretakers] = useState([])
     const [allOwners, registerOwners] = useState([])
     const [classes, defineClasses] = useState("card animal")
     const { getCurrentUser } = useSimpleAuth()
@@ -32,15 +34,27 @@ export const Animal = ({ animal, syncAnimals,
         if (owners) {
             registerOwners(owners)
         }
-    }, [owners])
+    }, [owners]) 
 
-   
+    useEffect(() => {
+        AnimalRepository.getCaretakers()
+            .then(data => assignCaretakers(data))
+    }, [])
+
+    useEffect(() => {
+        AnimalRepository.getCaretakersByAnimal(animalId)
+            .then(carers => setCaretakers(carers))
+    }, [])
+
+    const setUserId = () => {
+        evt.target.value ===
+    }
+
     const getPeople = () => {
         return AnimalOwnerRepository
             .getOwnersByAnimal(currentAnimal.id)
             .then(people => setPeople(people))
     }
-
 
     useEffect(() => {
         getPeople()
@@ -99,6 +113,24 @@ return (
                         
                             </span>
 
+                            {getCurrentUser().employee
+                            ?
+                            
+                                myCaretakers.length < 2
+                                    ? <select defaultValue=""
+                                        name="caretaker"
+                                        className="form-control small"
+                                        onChange={() => {}} >
+                                        <option value="">
+                                            Select {myCaretakers.length === 1 ? "a" : "another"} caretaker
+                                        </option>
+                                        {
+                                            allCaretakers.map(c => <option key={c.id} value={c.id}>{c.user.name}</option>)
+                                        }
+                                    </select>
+                                    : null
+                            
+                            : ""}
 
                             <h6>Owners</h6>
                             <span className="small">

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -100,6 +100,24 @@ export const Animal = ({ animal, syncAnimals,
             })
     }
 
+    const postCaretaker = (event) => {
+        const caretaker = {
+            userId: parseInt(event.target.value),
+            animalId: currentAnimal?.id
+        }
+        const fetchOption = {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(caretaker)
+        }
+        return fetch("http://localhost:8088/animalCaretakers", fetchOption)
+            .then(() => {
+                history.push("/animals")
+            })
+    }
+
     return (
         <>
             <li className={classes}>

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -6,9 +6,10 @@ import OwnerRepository from "../../repositories/OwnerRepository";
 import useSimpleAuth from "../../hooks/ui/useSimpleAuth";
 import useResourceResolver from "../../hooks/resource/useResourceResolver";
 import "./AnimalCard.css"
+import EmployeeRepository from "../../repositories/EmployeeRepository";
 
 export const Animal = ({ animal, syncAnimals,
-    showTreatmentHistory, owners }) => {
+    showTreatmentHistory, owners, caretakers }) => {
     const [detailsOpen, setDetailsOpen] = useState(false)
     const [isEmployee, setAuth] = useState(false)
     const [myOwners, setPeople] = useState([])
@@ -40,14 +41,18 @@ export const Animal = ({ animal, syncAnimals,
     }, [owners]) 
 
     useEffect(() => {
-        AnimalRepository.getCaretakers()
+        EmployeeRepository.getAll()
             .then(data => assignCaretakers(data))
     }, [])
 
+    const getEmps = () => {
+        return AnimalRepository.getCaretakersByAnimal(animalId)
+        .then(carers => setCaretakers(carers))
+    }
+
     useEffect(() => {
-        AnimalRepository.getCaretakersByAnimal(animalId)
-            .then(carers => setCaretakers(carers))
-    }, [])
+        getEmps()
+    }, [currentAnimal])
 
     const getPeople = () => {
         return AnimalOwnerRepository
@@ -161,12 +166,12 @@ export const Animal = ({ animal, syncAnimals,
                                     ? <select defaultValue=""
                                         name="caretaker"
                                         className="form-control small"
-                                        onChange={() => {}} >
+                                        onChange={(event) => {postCaretaker(event)}} >
                                         <option value="">
                                             Select {myCaretakers.length === 1 ? "a" : "another"} caretaker
                                         </option>
                                         {
-                                            allCaretakers.map(c => <option key={c.id} value={c.id}>{c.user.name}</option>)
+                                            allCaretakers.map(c => <option key={c.id} value={c.id}>{c.name}</option>)
                                         }
                                     </select>
                                     : null

--- a/src/components/animals/AnimalList.js
+++ b/src/components/animals/AnimalList.js
@@ -48,7 +48,6 @@ export const AnimalListComponent = (props) => {
         return () => window.removeEventListener("keyup", handler)
     }, [toggleDialog, modalIsOpen])
 
-
     return (
         <>
             <AnimalDialog toggleDialog={toggleDialog} animal={currentAnimal} />
@@ -69,6 +68,17 @@ export const AnimalListComponent = (props) => {
 
             <ul className="animals">
                 {
+                    getCurrentUser().employee
+                    ?
+                    animals.map(anml =>
+                        <Animal key={`animal--${anml.id}`} animal={anml}
+                            animalOwners={animalOwners}
+                            owners={owners}
+                            syncAnimals={syncAnimals}
+                            setAnimalOwners={setAnimalOwners}
+                            showTreatmentHistory={showTreatmentHistory}
+                        />)
+                    :
                     animals.map(anml =>
                         <Animal key={`animal--${anml.id}`} animal={anml}
                             animalOwners={animalOwners}

--- a/src/repositories/AnimalRepository.js
+++ b/src/repositories/AnimalRepository.js
@@ -31,14 +31,7 @@ export default {
     async getCaretakersByAnimal (animalId) {
         const e = await fetch(`${Settings.remoteURL}/animalCaretakers?animalId=${animalId}&_expand=user`)
         return await e.json()
-    },
-    async addCaretaker(newCaretaker) {
-        return await fetchIt(
-            `${Settings.remoteURL}/animalCaretakers`,
-            "POST",
-            JSON.stringify(newAnimal)
-        )
-    },
+    },  
     async searchByName(query) {
         return await fetchIt(`${Settings.remoteURL}/animals?_expand=employee&_sort=employee.id&_embed=treatments&_expand=location&name_like=${query}`)
     },

--- a/src/repositories/AnimalRepository.js
+++ b/src/repositories/AnimalRepository.js
@@ -25,6 +25,20 @@ export default {
                 return animal
             })
     },
+    async getCaretakers() {
+        return await fetchIt(`${Settings.remoteURL}/animalCaretakers?&_expand=user`)
+    },
+    async getCaretakersByAnimal (animalId) {
+        const e = await fetch(`${Settings.remoteURL}/animalCaretakers?animalId=${animalId}&_expand=user`)
+        return await e.json()
+    },
+    async addCaretaker(newCaretaker) {
+        return await fetchIt(
+            `${Settings.remoteURL}/animalCaretakers`,
+            "POST",
+            JSON.stringify(newAnimal)
+        )
+    },
     async searchByName(query) {
         return await fetchIt(`${Settings.remoteURL}/animals?_expand=employee&_sort=employee.id&_embed=treatments&_expand=location&name_like=${query}`)
     },

--- a/src/repositories/AnimalRepository.js
+++ b/src/repositories/AnimalRepository.js
@@ -1,6 +1,7 @@
 import Settings from "./Settings"
 import { fetchIt } from "./Fetch"
 import OwnerRepository from "./OwnerRepository"
+import EmployeeRepository from "./EmployeeRepository"
 
 const expandAnimalUser = (animal, users) => {
     animal.animalOwners = animal.animalOwners.map(ao => {
@@ -24,9 +25,6 @@ export default {
                 animal = expandAnimalUser(animal, users)
                 return animal
             })
-    },
-    async getCaretakers() {
-        return await fetchIt(`${Settings.remoteURL}/animalCaretakers?&_expand=user`)
     },
     async getCaretakersByAnimal (animalId) {
         const e = await fetch(`${Settings.remoteURL}/animalCaretakers?animalId=${animalId}&_expand=user`)


### PR DESCRIPTION
**Changes Made
Modified AnimalRepository and Animal.js to render a dropdown menu under caretakers only when an employee is logged in. The selection of an employee from the list will create a new animalCaretakers object in the api. The change does not render in the DOM until page reload though. 
Steps to Review
Checkout this branch locally.
git fetch --all
git checkout ad-customer-view
Open a new Terminal tab (⌘T) and navigate to the server directory.
Test app functionality.
When logged in as customer, no dropdown under caretakers. When logged in as an employee, dropdown renders under caretakers and you may select. You can see it post to API. Upon page reload, the caretakers list renders with the new name and the dropdown is reset to default. 
View code file.
Confirm file modifications are present as indicated above. Confirm no unused code or extraneous comments exist.